### PR TITLE
Expose object header

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dev = [
     "pre-commit",
     "pytest-cov",
     "pytest",
+    "pytest-lazy-fixture",
     "rich",
     "ruff",
     "mkdocs-material",
@@ -103,6 +104,7 @@ extend-ignore = [
 [tool.hatch.envs.default]
 dependencies = [
   "pytest",
+  "pytest-lazy-fixture",
 ]
 
 [tool.hatch.envs.default.scripts]

--- a/src/imodmodel/models.py
+++ b/src/imodmodel/models.py
@@ -228,6 +228,7 @@ class View(BaseModel):
 
 class Object(BaseModel):
     """https://bio3d.colorado.edu/imod/doc/binspec.html"""
+    header: ObjectHeader
     contours: List[Contour] = []
     meshes: List[Mesh] = []
     extra: List[GeneralStorage] = []

--- a/src/imodmodel/parsers.py
+++ b/src/imodmodel/parsers.py
@@ -81,8 +81,8 @@ def _parse_object_header(file: BinaryIO) -> ObjectHeader:
 
 
 def _parse_object(file: BinaryIO) -> Object:
-    _parse_object_header(file)
-    return Object()
+    header = _parse_object_header(file)
+    return Object(header=header)
 
 
 def _parse_contour_header(file: BinaryIO) -> ContourHeader:

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -14,7 +14,6 @@ from imodmodel.models import Object, ObjectHeader, Contour, ContourHeader, Mesh,
 )
 def test_read(file, meshes_expected):
     """Check the model based API"""
-
     model = ImodModel.from_file(file)
     assert isinstance(model, ImodModel)
     assert len(model.objects) == 1

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -1,0 +1,28 @@
+import pytest
+from pytest_lazyfixture import lazy_fixture
+
+from imodmodel import ImodModel
+from imodmodel.models import Object, ObjectHeader, Contour, ContourHeader, Mesh, MeshHeader
+
+@pytest.mark.parametrize(
+    "file, meshes_expected",
+    [
+        (lazy_fixture('two_contour_model_file'), 0),
+        (lazy_fixture('meshed_contour_model_file'), 1),
+
+    ]
+)
+def test_read(file, meshes_expected):
+    """Check the model based API"""
+
+    model = ImodModel.from_file(file)
+    assert isinstance(model, ImodModel)
+    assert len(model.objects) == 1
+    assert isinstance(model.objects[0], Object)
+    assert isinstance(model.objects[0].header, ObjectHeader)
+    assert isinstance(model.objects[0].contours[0], Contour)
+    assert isinstance(model.objects[0].contours[0].header, ContourHeader)
+    assert len(model.objects[0].meshes) == meshes_expected
+    if meshes_expected:
+        assert isinstance(model.objects[0].meshes[0], Mesh)
+        assert isinstance(model.objects[0].meshes[0].header, MeshHeader)


### PR DESCRIPTION
This is just a small fix to expose the `ObjectHeader` model in the `ImodModel` + some tests of the new `ImodModel` API