### PR TITLE
Make tests compatible with pytest >= 8.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ dev = [
     "pre-commit",
     "pytest-cov",
     "pytest",
-    "pytest-lazy-fixture",
     "rich",
     "ruff",
     "mkdocs-material",
@@ -104,7 +103,6 @@ extend-ignore = [
 [tool.hatch.envs.default]
 dependencies = [
   "pytest",
-  "pytest-lazy-fixture",
 ]
 
 [tool.hatch.envs.default.scripts]

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -1,19 +1,26 @@
 import pytest
-from pytest_lazyfixture import lazy_fixture
-
 from imodmodel import ImodModel
-from imodmodel.models import Object, ObjectHeader, Contour, ContourHeader, Mesh, MeshHeader
+from imodmodel.models import (
+    Contour,
+    ContourHeader,
+    Mesh,
+    MeshHeader,
+    Object,
+    ObjectHeader,
+)
+
 
 @pytest.mark.parametrize(
-    "file, meshes_expected",
+    "file_fixture, meshes_expected",
     [
-        (lazy_fixture('two_contour_model_file'), 0),
-        (lazy_fixture('meshed_contour_model_file'), 1),
+        ('two_contour_model_file', 0),
+        ('meshed_contour_model_file', 1),
 
     ]
 )
-def test_read(file, meshes_expected):
+def test_read(file_fixture, meshes_expected, request):
     """Check the model based API"""
+    file = request.getfixturevalue(file_fixture)
     model = ImodModel.from_file(file)
     assert isinstance(model, ImodModel)
     assert len(model.objects) == 1


### PR DESCRIPTION
Fixes #11 by implementing the fix suggested [here](https://github.com/TvoroG/pytest-lazy-fixture/issues/65#issuecomment-1914527162) and dropping the `pytest-lazy-fixture` requirement. 

@alisterburt would be nice to merge this ahead of the pydantic bump so the tests work.