### PR TITLE
Migrate to pydantic v2 API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dynamic = ["version"]
 dependencies = [
     "numpy",
     "pandas",
-    "pydantic",
+    "pydantic>=2",
 ]
 
 # extras
@@ -112,11 +112,10 @@ test = "pytest {args:tests}"
 matrix-name-format = "{variable}_{value}"
 
 [[tool.hatch.envs.all.matrix]]
-pydantic_version = ["1","2"]
+pydantic_version = ["2"]
 
 [tool.hatch.envs.all.overrides]
 matrix.pydantic_version.dependencies = [
-    { value="pydantic<2", if = ["1"] },
     { value="pydantic>=2", if = ["2"] }
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ dev = [
     "pre-commit",
     "pytest-cov",
     "pytest",
-    "pytest-lazy-fixture",
     "rich",
     "ruff",
     "mkdocs-material",
@@ -104,7 +103,6 @@ extend-ignore = [
 [tool.hatch.envs.default]
 dependencies = [
   "pytest",
-  "pytest-lazy-fixture",
 ]
 
 [tool.hatch.envs.default.scripts]

--- a/src/imodmodel/models.py
+++ b/src/imodmodel/models.py
@@ -1,10 +1,9 @@
 import os
 import warnings
-from typing import Tuple, List, Optional, Union
+from typing import List, Optional, Tuple, Union
 
 import numpy as np
-from pydantic import field_validator, ConfigDict, BaseModel
-from pydantic.version import VERSION as PYDANTIC_VERSION
+from pydantic import BaseModel, ConfigDict, field_validator
 
 
 class ID(BaseModel):

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -1,19 +1,26 @@
 import pytest
-from pytest_lazyfixture import lazy_fixture
-
 from imodmodel import ImodModel
-from imodmodel.models import Object, ObjectHeader, Contour, ContourHeader, Mesh, MeshHeader
+from imodmodel.models import (
+    Contour,
+    ContourHeader,
+    Mesh,
+    MeshHeader,
+    Object,
+    ObjectHeader,
+)
+
 
 @pytest.mark.parametrize(
-    "file, meshes_expected",
+    "file_fixture, meshes_expected",
     [
-        (lazy_fixture('two_contour_model_file'), 0),
-        (lazy_fixture('meshed_contour_model_file'), 1),
+        ('two_contour_model_file', 0),
+        ('meshed_contour_model_file', 1),
 
     ]
 )
-def test_read(file, meshes_expected):
+def test_read(file_fixture, meshes_expected, request):
     """Check the model based API"""
+    file = request.getfixturevalue(file_fixture)
     model = ImodModel.from_file(file)
     assert isinstance(model, ImodModel)
     assert len(model.objects) == 1


### PR DESCRIPTION
Adressing #10 

- Removes tests for `pydantic<=2`
- Adds requirement `pydantic>=2`
- migrates models in `models.py` to pydantic v2 API

Depends on PR #12 