### PR TITLE
slan example

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,7 @@ These annotations can be read in by setting `annotation = 'slan'` when calling `
 ```python
 import imodmodel
 
-df = imodmodel.read('file_with_slicer_angles.mod')
+df = imodmodel.read('file_with_slicer_angles.mod', annotation='slan')
 ```
 
 ```ipython

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,7 @@ Out[3]:
 
 Annotations made in the [slicer window](https://bio3d.colorado.edu/imod/doc/3dmodHelp/slicer.html) are stored in the IMOD binary file with both centerpoints and angles.
 
-These annotations can be read in by setting `annotation = 'slan'` when calling `imodmodel.read()`
+These annotations can be read in by setting `annotation='slan'` when calling `imodmodel.read()`
 
 ```python
 import imodmodel

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,6 +30,26 @@ Out[3]:
 
 ```
 
+Annotations made in the [slicer window](https://bio3d.colorado.edu/imod/doc/3dmodHelp/slicer.html) are stored in the IMOD binary file with both centerpoints and angles.
+
+These annotations can be read in by setting `annotation = 'slan'` when calling `imodmodel.read()`
+
+```python
+import imodmodel
+
+df = imodmodel.read('file_with_slicer_angles.mod')
+```
+
+```ipython
+In [3]: df.head()
+Out[3]:
+   object_id  slan_id  time      x_rot  y_rot      z_rot    center_x    center_y  center_z label
+0          0        0     1  13.100000    0.0 -30.200001  235.519577  682.744141     302.0
+0          0        1     1 -41.400002    0.0 -47.700001  221.942444  661.193237     327.0
+0          0        2     1 -41.400002    0.0 -41.799999  232.790726  671.332031     327.0
+0          0        3     1 -35.500000    0.0 -36.000000  240.129181  679.927795     324.0
+```
+
 That's it!
 
 ## Installation


### PR DESCRIPTION
Added simple slan example to usage. Let me know if I should explain more.

Things I can add:

1. Why orientations matter? (macro molecular complexes are at times easier to see at different views through the tomogram)
2. Preprocessing for Machine learning. For example, the dataset used for [this](https://www.kaggle.com/competitions/byu-locating-bacterial-flagellar-motors-v2) kaggle competition used the angles in combination with IMOD's rotatevol() function to get the best looking slices from the tomogram.

By the way, this is hopefully going to be used by the cryoet data portal for converting .mod to .ndjson. They would consider these annotations to be oriented points which I believe napari can handle. 