### PR TITLE
feat: Add support for reading model-to-image transformation information.

### DIFF
--- a/src/imodmodel/binary_specification.py
+++ b/src/imodmodel/binary_specification.py
@@ -83,7 +83,6 @@ class ModFileSpecification:
         'matflags2': 'B',
         'mat3b3': 'B'
     }
-
     VIEW = {
         'fovy': 'f',
         'rad': 'f',
@@ -110,10 +109,16 @@ class ModFileSpecification:
         'center': '3f',
         'label': '32c'
     }
-
+    MINX = {
+        'oscale': '3f',
+        'otrans': '3f',
+        'orot': '3f',
+        'cscale': '3f',
+        'ctrans': '3f',
+        'crot': '3f',
+    }
     SIZE = NotImplemented
     MESH = NotImplemented
-    MINX = NotImplemented
     LABL = NotImplemented
     OLBL = NotImplemented
     CLIP = NotImplemented

--- a/src/imodmodel/models.py
+++ b/src/imodmodel/models.py
@@ -188,6 +188,15 @@ class IMAT(BaseModel):
     matflags2: int
     mat3b3: int
 
+class MINX(BaseModel):
+    """https://bio3d.colorado.edu/imod/doc/binspec.html"""
+    oscale: Tuple[float, float, float]
+    otrans: Tuple[float, float, float]
+    orot: Tuple[float, float, float]
+    cscale: Tuple[float, float, float]
+    ctrans: Tuple[float, float, float]
+    crot: Tuple[float, float, float]
+
 
 class Size(BaseModel):
     """https://bio3d.colorado.edu/imod/doc/binspec.html"""
@@ -246,6 +255,7 @@ class ImodModel(BaseModel):
     header: ModelHeader
     objects: List[Object]
     slicer_angles: List[SLAN] = []
+    minx: Optional[MINX]
     extra: List[GeneralStorage] = []
 
     @classmethod

--- a/src/imodmodel/parsers.py
+++ b/src/imodmodel/parsers.py
@@ -13,6 +13,7 @@ from .models import (
     GeneralStorage,
     Mesh,
     MeshHeader,
+    MINX,
     ImodModel,
     ModelHeader,
     Object,
@@ -130,6 +131,10 @@ def _parse_imat(file: BinaryIO) -> IMAT:
     data = _parse_from_specification(file, ModFileSpecification.IMAT)
     return IMAT(**data)
 
+def _parse_minx(file: BinaryIO) -> MINX:
+    _parse_chunk_size(file)
+    data = _parse_from_specification(file, ModFileSpecification.MINX)
+    return MINX(**data)
 
 def _parse_general_storage(file: BinaryIO) -> List[GeneralStorage]:
     size = _parse_chunk_size(file)
@@ -159,6 +164,7 @@ def parse_model(file: BinaryIO) -> ImodModel:
     header = _parse_model_header(file)
     control_sequence = _parse_control_sequence(file)
     slicer_angles = []
+    minx = None
     extra = list()
 
     objects = []
@@ -181,7 +187,9 @@ def parse_model(file: BinaryIO) -> ImodModel:
             objects[-1].meshes[-1].extra += _parse_general_storage(file)
         elif control_sequence == "SLAN":
             slicer_angles.append(_parse_slicer_angle(file))
+        elif control_sequence == "MINX":
+            minx = _parse_minx(file)
         else:
             _parse_unknown(file)
         control_sequence = _parse_control_sequence(file)
-    return ImodModel(id=id, header=header, objects=objects, slicer_angles=slicer_angles, extra=extra)
+    return ImodModel(id=id, header=header, objects=objects, slicer_angles=slicer_angles, minx=minx, extra=extra)

--- a/tests/test_model_api.py
+++ b/tests/test_model_api.py
@@ -69,3 +69,13 @@ def test_multiple_objects(file_fixture_multiple_objects, objects_expected, reque
     assert isinstance(model.objects[2].contours[0], Contour)
 
 
+def test_read_minx(meshed_contour_model_file):
+    """Check reading of model to image transformation information."""
+    model = ImodModel.from_file(meshed_contour_model_file)
+    assert isinstance(model, ImodModel)
+    assert model.minx.cscale == pytest.approx((10.680000, 10.680000, 10.680000), abs=1e-6)
+    assert model.minx.ctrans == pytest.approx((-2228.0, 2228.0, 681.099976), abs=1e-6)
+    assert model.minx.crot == pytest.approx((0.0, 0.0, 0.0), abs=1e-6)
+
+
+


### PR DESCRIPTION
IMOD stores model-to-image transforms in an optional chunk called `MINX` with the below contents: 

```
Length Type         Name     Description
------------------------------------------------------------------------------
12     float * 3    oscale   Old scale values (unused in file) 
12     float * 3    otrans   Old translations (file stores image origin values)
12     float * 3    orot     Old rotations around X, Y, Z axes (unused in file)
12     float * 3    cscale   New scale values in X, Y, Z
12     float * 3    ctrans   New translations in X, Y, Z
12     float * 3    crot     New rotations around X, Y, Z axes
```
See also: [imod binspec](https://bio3d.colorado.edu/imod/doc/binspec.html)

This PR adds support for parsing the `MINX` chunk using the model based API and stores it in a field called `minx` in the parsed `ImodModel`. Also adds a test for parsing. 